### PR TITLE
[Zvbc32e] Adding -02 test for vclmul[h].v[vx] for Zvbc32e

### DIFF
--- a/riscv-test-suite/rv32i_m/Zvk/src/vclmul.vv-02.S
+++ b/riscv-test-suite/rv32i_m/Zvk/src/vclmul.vv-02.S
@@ -11,7 +11,7 @@
 
 #include "test_macros_vector.h"
 
-RVTEST_ISA("RV32IV_Zicsr_Zvkb,RV64IV_Zicsr_Zvkb")
+RVTEST_ISA("RV32IV_Zicsr_Zvbc32,RV64IV_Zicsr_Zvbc32e")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvkb);def TEST_CASE_1=True;",vclmul.vv)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvbc32e);def TEST_CASE_1=True;",vclmul.vv)
 
 RVTEST_V_ENABLE()
 RVTEST_VALBASEUPD(DATA_BASE, dataset_tc1)
@@ -33,57 +33,57 @@ RVTEST_SIGBASE(SIG_BASE, signature_tc1)
 // - input VS2: Multiplicand
 // - input VM: Mask encoding (<nothing> or v0.t)
 // - output VD: Carry-less product (low-half)
-// VCLMUL.VV requires that SEW=64 (Zvbc)
+// VCLMUL.VV requires that SEW=16, 32, or 64 (Zvbc32e)
 
 #define VINST vclmul.vv
 
 inst_0:
 // This test will define v0, which will later be used as mask register
-TEST_CASE_VVV(1, 64, VINST, v0, v1, 0*8, v2, 1*8)
+TEST_CASE_VVV(1, 8, VINST, v0, v1, 0*8, v2, 1*8)
 //sig[8*1]
 
 inst_1:
-TEST_CASE_VVV(1, 64, VINST, v5, v4, 2*8, v3, 3*8)
+TEST_CASE_VVV(1, 8, VINST, v5, v4, 2*8, v3, 3*8)
 //sig[8*2]
 
 inst_2:
-TEST_CASE_VVV(1, 64, VINST, v6, v7, 4*8, v8, 5*8)
+TEST_CASE_VVV(1, 8, VINST, v6, v7, 4*8, v8, 5*8)
 //sig[8*3]
 
 inst_3:
-TEST_CASE_VVV(1, 64, VINST, v9, v10, 7*8, v11, 6*8)
+TEST_CASE_VVV(1, 8, VINST, v9, v10, 7*8, v11, 6*8)
 //sig[8*4]
 
 inst_4:
-TEST_CASE_VVV_M(2, 64, VINST, v12, v13, 2*8, v14, 3*8)
+TEST_CASE_VVV_M(2, 8, VINST, v12, v13, 2*8, v14, 3*8)
 //sig[8*6]
 
 inst_5:
-TEST_CASE_VVV(2, 64, VINST, v15, v16, 2*8, v17, 3*8)
+TEST_CASE_VVV(2, 8, VINST, v15, v16, 2*8, v17, 3*8)
 //sig[8*8]
 
 inst_6:
-TEST_CASE_VVV_M(2, 64, VINST, v18, v19, 2*8, v20, 3*8)
+TEST_CASE_VVV_M(2, 8, VINST, v18, v19, 2*8, v20, 3*8)
 //sig[8*10]
 
 inst_7:
-TEST_CASE_VVV_M(2, 64, VINST, v21, v22, 2*8, v23, 3*8)
+TEST_CASE_VVV_M(2, 8, VINST, v21, v22, 2*8, v23, 3*8)
 //sig[8*12]
 
 inst_8:
-TEST_CASE_VVV(4, 64, VINST, v24, v25, 0*8, v26, 4*8)
+TEST_CASE_VVV(4, 8, VINST, v24, v25, 0*8, v26, 4*8)
 //sig[8*16]
 
 inst_9:
-TEST_CASE_VVV(4, 64, VINST, v27, v28, 4*8, v29, 0*8)
+TEST_CASE_VVV(4, 8, VINST, v27, v28, 4*8, v29, 0*8)
 //sig[8*20]
 
 inst_10:
-TEST_CASE_VVV(4, 64, VINST, v30, v31, 0*8, v2, 0*8)
+TEST_CASE_VVV(4, 8, VINST, v30, v31, 0*8, v2, 0*8)
 //sig[8*24]
 
 inst_11:
-TEST_CASE_VVV_M(4, 64, VINST, v1, v15, 4*8, v31, 4*8)
+TEST_CASE_VVV_M(4, 8, VINST, v1, v15, 4*8, v31, 4*8)
 //sig[8*28]
 
 #endif // TEST_CASE_1

--- a/riscv-test-suite/rv32i_m/Zvk/src/vclmul.vx-02.S
+++ b/riscv-test-suite/rv32i_m/Zvk/src/vclmul.vx-02.S
@@ -1,7 +1,7 @@
 // Copyright (c) 2023. RISC-V International. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // -----------
-// This assembly file tests the vclmul.vv instruction.
+// This assembly file tests the vclmul.vx instruction.
 
 // Define special purpose registers before including test_macros_vector.h
 #define DATA_BASE x3
@@ -11,7 +11,7 @@
 
 #include "test_macros_vector.h"
 
-RVTEST_ISA("RV32IV_Zicsr_Zvkb,RV64IV_Zicsr_Zvkb")
+RVTEST_ISA("RV32IV_Zicsr_Zvbc32e,RV64IV_Zicsr_Zvbc32e")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,68 +22,68 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvkb);def TEST_CASE_1=True;",vclmul.vv)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvbc32e);def TEST_CASE_1=True;",vclmul.vx)
 
 RVTEST_V_ENABLE()
 RVTEST_VALBASEUPD(DATA_BASE, dataset_tc1)
 RVTEST_SIGBASE(SIG_BASE, signature_tc1)
 
-// VCLMUL.VV has the following inputs and outputs:
+// VCLMUL.VX has the following inputs and outputs:
 // - input VS1: Multiplier
 // - input VS2: Multiplicand
 // - input VM: Mask encoding (<nothing> or v0.t)
 // - output VD: Carry-less product (low-half)
-// VCLMUL.VV requires that SEW=64 (Zvbc)
+// VCLMUL.VX requires that SEW=64
 
-#define VINST vclmul.vv
+#define VINST vclmul.vx
 
 inst_0:
 // This test will define v0, which will later be used as mask register
-TEST_CASE_VVV(1, 64, VINST, v0, v1, 0*8, v2, 1*8)
+TEST_CASE_VVR(1, 8, VINST, v0, v1, 0*8, x7, 1*8)
 //sig[8*1]
 
 inst_1:
-TEST_CASE_VVV(1, 64, VINST, v5, v4, 2*8, v3, 3*8)
+TEST_CASE_VVR(1, 8, VINST, v5, v4, 2*8, x7, 3*8)
 //sig[8*2]
 
 inst_2:
-TEST_CASE_VVV(1, 64, VINST, v6, v7, 4*8, v8, 5*8)
+TEST_CASE_VVR(1, 8, VINST, v6, v7, 4*8, x8, 5*8)
 //sig[8*3]
 
 inst_3:
-TEST_CASE_VVV(1, 64, VINST, v9, v10, 7*8, v11, 6*8)
+TEST_CASE_VVR(1, 8, VINST, v9, v10, 7*8, x11, 6*8)
 //sig[8*4]
 
 inst_4:
-TEST_CASE_VVV_M(2, 64, VINST, v12, v13, 2*8, v14, 3*8)
+TEST_CASE_VVR_M(2, 8, VINST, v12, v13, 2*8, x14, 3*8)
 //sig[8*6]
 
 inst_5:
-TEST_CASE_VVV(2, 64, VINST, v15, v16, 2*8, v17, 3*8)
+TEST_CASE_VVR(2, 8, VINST, v15, v16, 2*8, x17, 3*8)
 //sig[8*8]
 
 inst_6:
-TEST_CASE_VVV_M(2, 64, VINST, v18, v19, 2*8, v20, 3*8)
+TEST_CASE_VVR_M(2, 8, VINST, v18, v19, 2*8, x20, 3*8)
 //sig[8*10]
 
 inst_7:
-TEST_CASE_VVV_M(2, 64, VINST, v21, v22, 2*8, v23, 3*8)
+TEST_CASE_VVR_M(2, 8, VINST, v21, v22, 2*8, x23, 3*8)
 //sig[8*12]
 
 inst_8:
-TEST_CASE_VVV(4, 64, VINST, v24, v25, 0*8, v26, 4*8)
+TEST_CASE_VVR(4, 8, VINST, v24, v25, 0*8, x26, 4*8)
 //sig[8*16]
 
 inst_9:
-TEST_CASE_VVV(4, 64, VINST, v27, v28, 4*8, v29, 0*8)
+TEST_CASE_VVR(4, 8, VINST, v27, v28, 4*8, x29, 0*8)
 //sig[8*20]
 
 inst_10:
-TEST_CASE_VVV(4, 64, VINST, v30, v31, 0*8, v2, 0*8)
+TEST_CASE_VVR(4, 8, VINST, v30, v31, 0*8, x7, 0*8)
 //sig[8*24]
 
 inst_11:
-TEST_CASE_VVV_M(4, 64, VINST, v1, v15, 4*8, v31, 4*8)
+TEST_CASE_VVR_M(4, 8, VINST, v1, v15, 4*8, x31, 4*8)
 //sig[8*28]
 
 #endif // TEST_CASE_1

--- a/riscv-test-suite/rv32i_m/Zvk/src/vclmulh.vv-02.S
+++ b/riscv-test-suite/rv32i_m/Zvk/src/vclmulh.vv-02.S
@@ -1,7 +1,7 @@
 // Copyright (c) 2023. RISC-V International. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // -----------
-// This assembly file tests the vclmul.vv instruction.
+// This assembly file tests the vclmulh.vv instruction.
 
 // Define special purpose registers before including test_macros_vector.h
 #define DATA_BASE x3
@@ -11,7 +11,7 @@
 
 #include "test_macros_vector.h"
 
-RVTEST_ISA("RV32IV_Zicsr_Zvkb,RV64IV_Zicsr_Zvkb")
+RVTEST_ISA("RV32IV_Zicsr_Zvbc32e,RV64IV_Zicsr_Zvbc32e")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,68 +22,68 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvkb);def TEST_CASE_1=True;",vclmul.vv)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvbc32e);def TEST_CASE_1=True;",vclmulh.vv)
 
 RVTEST_V_ENABLE()
 RVTEST_VALBASEUPD(DATA_BASE, dataset_tc1)
 RVTEST_SIGBASE(SIG_BASE, signature_tc1)
 
-// VCLMUL.VV has the following inputs and outputs:
+// VCLMULH.VV has the following inputs and outputs:
 // - input VS1: Multiplier
 // - input VS2: Multiplicand
 // - input VM: Mask encoding (<nothing> or v0.t)
 // - output VD: Carry-less product (low-half)
-// VCLMUL.VV requires that SEW=64 (Zvbc)
+// VCLMULH.VV requires that SEW=64
 
-#define VINST vclmul.vv
+#define VINST vclmulh.vv
 
 inst_0:
 // This test will define v0, which will later be used as mask register
-TEST_CASE_VVV(1, 64, VINST, v0, v1, 0*8, v2, 1*8)
+TEST_CASE_VVV(1, 8, VINST, v0, v1, 0*8, v2, 1*8)
 //sig[8*1]
 
 inst_1:
-TEST_CASE_VVV(1, 64, VINST, v5, v4, 2*8, v3, 3*8)
+TEST_CASE_VVV(1, 8, VINST, v5, v4, 2*8, v3, 3*8)
 //sig[8*2]
 
 inst_2:
-TEST_CASE_VVV(1, 64, VINST, v6, v7, 4*8, v8, 5*8)
+TEST_CASE_VVV(1, 8, VINST, v6, v7, 4*8, v8, 5*8)
 //sig[8*3]
 
 inst_3:
-TEST_CASE_VVV(1, 64, VINST, v9, v10, 7*8, v11, 6*8)
+TEST_CASE_VVV(1, 8, VINST, v9, v10, 7*8, v11, 6*8)
 //sig[8*4]
 
 inst_4:
-TEST_CASE_VVV_M(2, 64, VINST, v12, v13, 2*8, v14, 3*8)
+TEST_CASE_VVV_M(2, 8, VINST, v12, v13, 2*8, v14, 3*8)
 //sig[8*6]
 
 inst_5:
-TEST_CASE_VVV(2, 64, VINST, v15, v16, 2*8, v17, 3*8)
+TEST_CASE_VVV(2, 8, VINST, v15, v16, 2*8, v17, 3*8)
 //sig[8*8]
 
 inst_6:
-TEST_CASE_VVV_M(2, 64, VINST, v18, v19, 2*8, v20, 3*8)
+TEST_CASE_VVV_M(2, 8, VINST, v18, v19, 2*8, v20, 3*8)
 //sig[8*10]
 
 inst_7:
-TEST_CASE_VVV_M(2, 64, VINST, v21, v22, 2*8, v23, 3*8)
+TEST_CASE_VVV_M(2, 8, VINST, v21, v22, 2*8, v23, 3*8)
 //sig[8*12]
 
 inst_8:
-TEST_CASE_VVV(4, 64, VINST, v24, v25, 0*8, v26, 4*8)
+TEST_CASE_VVV(4, 8, VINST, v24, v25, 0*8, v26, 4*8)
 //sig[8*16]
 
 inst_9:
-TEST_CASE_VVV(4, 64, VINST, v27, v28, 4*8, v29, 0*8)
+TEST_CASE_VVV(4, 8, VINST, v27, v28, 4*8, v29, 0*8)
 //sig[8*20]
 
 inst_10:
-TEST_CASE_VVV(4, 64, VINST, v30, v31, 0*8, v2, 0*8)
+TEST_CASE_VVV(4, 8, VINST, v30, v31, 0*8, v2, 0*8)
 //sig[8*24]
 
 inst_11:
-TEST_CASE_VVV_M(4, 64, VINST, v1, v15, 4*8, v31, 4*8)
+TEST_CASE_VVV_M(4, 8, VINST, v1, v15, 4*8, v31, 4*8)
 //sig[8*28]
 
 #endif // TEST_CASE_1

--- a/riscv-test-suite/rv32i_m/Zvk/src/vclmulh.vx-02.S
+++ b/riscv-test-suite/rv32i_m/Zvk/src/vclmulh.vx-02.S
@@ -1,7 +1,7 @@
 // Copyright (c) 2023. RISC-V International. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // -----------
-// This assembly file tests the vclmul.vv instruction.
+// This assembly file tests the vclmulh.vx instruction.
 
 // Define special purpose registers before including test_macros_vector.h
 #define DATA_BASE x3
@@ -11,7 +11,7 @@
 
 #include "test_macros_vector.h"
 
-RVTEST_ISA("RV32IV_Zicsr_Zvkb,RV64IV_Zicsr_Zvkb")
+RVTEST_ISA("RV32IV_Zicsr_Zvbc32e,RV64IV_Zicsr_Zvbc32e")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,68 +22,68 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvkb);def TEST_CASE_1=True;",vclmul.vv)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvbc32e);def TEST_CASE_1=True;",vclmulh.vx)
 
 RVTEST_V_ENABLE()
 RVTEST_VALBASEUPD(DATA_BASE, dataset_tc1)
 RVTEST_SIGBASE(SIG_BASE, signature_tc1)
 
-// VCLMUL.VV has the following inputs and outputs:
+// VCLMULH.VX has the following inputs and outputs:
 // - input VS1: Multiplier
 // - input VS2: Multiplicand
 // - input VM: Mask encoding (<nothing> or v0.t)
 // - output VD: Carry-less product (low-half)
-// VCLMUL.VV requires that SEW=64 (Zvbc)
+// VCLMULH.VX requires that SEW=64
 
-#define VINST vclmul.vv
+#define VINST vclmulh.vx
 
 inst_0:
 // This test will define v0, which will later be used as mask register
-TEST_CASE_VVV(1, 64, VINST, v0, v1, 0*8, v2, 1*8)
+TEST_CASE_VVR(1, 8, VINST, v0, v1, 0*8, x7, 1*8)
 //sig[8*1]
 
 inst_1:
-TEST_CASE_VVV(1, 64, VINST, v5, v4, 2*8, v3, 3*8)
+TEST_CASE_VVR(1, 8, VINST, v5, v4, 2*8, x7, 3*8)
 //sig[8*2]
 
 inst_2:
-TEST_CASE_VVV(1, 64, VINST, v6, v7, 4*8, v8, 5*8)
+TEST_CASE_VVR(1, 8, VINST, v6, v7, 4*8, x8, 5*8)
 //sig[8*3]
 
 inst_3:
-TEST_CASE_VVV(1, 64, VINST, v9, v10, 7*8, v11, 6*8)
+TEST_CASE_VVR(1, 8, VINST, v9, v10, 7*8, x11, 6*8)
 //sig[8*4]
 
 inst_4:
-TEST_CASE_VVV_M(2, 64, VINST, v12, v13, 2*8, v14, 3*8)
+TEST_CASE_VVR_M(2, 8, VINST, v12, v13, 2*8, x14, 3*8)
 //sig[8*6]
 
 inst_5:
-TEST_CASE_VVV(2, 64, VINST, v15, v16, 2*8, v17, 3*8)
+TEST_CASE_VVR(2, 8, VINST, v15, v16, 2*8, x17, 3*8)
 //sig[8*8]
 
 inst_6:
-TEST_CASE_VVV_M(2, 64, VINST, v18, v19, 2*8, v20, 3*8)
+TEST_CASE_VVR_M(2, 8, VINST, v18, v19, 2*8, x20, 3*8)
 //sig[8*10]
 
 inst_7:
-TEST_CASE_VVV_M(2, 64, VINST, v21, v22, 2*8, v23, 3*8)
+TEST_CASE_VVR_M(2, 8, VINST, v21, v22, 2*8, x23, 3*8)
 //sig[8*12]
 
 inst_8:
-TEST_CASE_VVV(4, 64, VINST, v24, v25, 0*8, v26, 4*8)
+TEST_CASE_VVR(4, 8, VINST, v24, v25, 0*8, x26, 4*8)
 //sig[8*16]
 
 inst_9:
-TEST_CASE_VVV(4, 64, VINST, v27, v28, 4*8, v29, 0*8)
+TEST_CASE_VVR(4, 8, VINST, v27, v28, 4*8, x29, 0*8)
 //sig[8*20]
 
 inst_10:
-TEST_CASE_VVV(4, 64, VINST, v30, v31, 0*8, v2, 0*8)
+TEST_CASE_VVR(4, 8, VINST, v30, v31, 0*8, x7, 0*8)
 //sig[8*24]
 
 inst_11:
-TEST_CASE_VVV_M(4, 64, VINST, v1, v15, 4*8, v31, 4*8)
+TEST_CASE_VVR_M(4, 8, VINST, v1, v15, 4*8, x31, 4*8)
 //sig[8*28]
 
 #endif // TEST_CASE_1


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Provide a detailed description of the changes performed by the PR.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist

### Ratified/Unratified Extensions

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [ ] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
